### PR TITLE
Rename zones to regions

### DIFF
--- a/actions_ips/ips.py
+++ b/actions_ips/ips.py
@@ -22,7 +22,7 @@ def cidrs():
     response.raise_for_status()
     data = response.json()
 
-    zones = [
+    regions = [
         "AzureCloud.eastus2",  # EUS2
         "AzureCloud.eastus",  # EUS
         "AzureCloud.westus",  # WUS
@@ -46,7 +46,7 @@ def cidrs():
     ips.add("143.55.64.0/23")
 
     for line in data["values"]:
-        if line["name"] in zones:
+        if line["name"] in regions:
             for address in line["properties"]["addressPrefixes"]:
                 ips.add(address)
 

--- a/ips.py
+++ b/ips.py
@@ -22,7 +22,7 @@ def cidrs():
     response.raise_for_status()
     data = response.json()
 
-    zones = [
+    regions = [
         "AzureCloud.eastus2",  # EUS2
         "AzureCloud.eastus",  # EUS
         "AzureCloud.westus",  # WUS
@@ -43,7 +43,7 @@ def cidrs():
     ips.add("208.83.5.230/32")
 
     for line in data["values"]:
-        if line["name"] in zones:
+        if line["name"] in regions:
             for address in line["properties"]["addressPrefixes"]:
                 ips.add(address)
 


### PR DESCRIPTION
To avoid confusion because there's [a concept of a zone with other Cloud providers](https://cloud.google.com/compute/docs/regions-zones#identifying_a_region_or_zone), and to keep things consistent with `AzureRegion` key used in scale unit configs, renaming zones to regions. 