### PR TITLE
Adding WestUS 3 as location where hosted runners can live.

### DIFF
--- a/actions_ips/ips.py
+++ b/actions_ips/ips.py
@@ -108,6 +108,7 @@ def cidrs():
         "AzureCloud.eastus",  # EUS
         "AzureCloud.westus",  # WUS
         "AzureCloud.westus2",  # WUS2
+        "AzureCloud.westus3",  # WUS3
         "AzureCloud.centralus",  # CUS
         "AzureCloud.southcentralus",  # SCUS
     ]


### PR DESCRIPTION
There are Actions Hosted Runners in Azure's WestUS 3 region now, so it should be included in meta endpoint output.